### PR TITLE
Placeholder Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,21 +42,20 @@ as well.
 you may use all the same classes and functions described in its documentation as well. To
 access the user-specific context settings call the `preference()` function anywhere you would
 normally use `setting()`:
-
 ```php
 class Home extends Controller
 {
     public function index()
     {
         return view('welcome', [
-            'theme' => preference('theme'),
+            'icon' => preference('Users.avatar'),
         ];
     }
 
-    public function update_theme()
+    public function update_avatar()
     {
-        if ($theme = $this->request->getPost('theme')) {
-            prefernece('theme', $theme);
+        if ($icon = $this->request->getPost('icon')) {
+            prefernece('Users.avatar', $icon);
         }
 
         return redirect()->back();
@@ -69,6 +68,35 @@ class Home extends Controller
 `preference()` will retrieve and store contextual settings for the current authenticated user.
 If no user is authenticated then it will fall back on the `Session` class with semi-persistent
 settings for as long as the session lasts.
+
+### Placeholder Config
+
+In most cases each setting should have a corresponding Config file. Sometimes these settings
+will not fit under an existing logical grouping, so this library provides a "placeholder"
+Config (`Tatter\Preferences\Config\Preferences`). You may add your own version in **app/* to
+supply default values:
+```php
+<?php
+
+namespace Config;
+
+class Preferences extends \Tatter\Preferences\Config\Preferences
+{
+    /**
+     * Slug for the current user theme.
+     */
+    public string $theme = 'midnight';
+}
+```
+
+Any function calls with the class unspecified will reference the `Preferences` class:
+```php
+// Identical calls:
+$theme = preference('Preferences.theme');
+$theme = preference('theme');
+```
+
+> Hint: Don't forget that libraries and modules can provide Config properties via [Registrars](https://codeigniter.com/user_guide/general/configuration.html#registrars)
 
 ## Troubleshooting
 

--- a/src/Config/Preferences.php
+++ b/src/Config/Preferences.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tatter\Preferences\Config;
+
+use CodeIgniter\Config\BaseConfig;
+
+/**
+ * Preferences Config
+ *
+ * A placeholder config file to provide a home
+ * for properties that may not fit elsewhere.
+ * Intended for use with CodeIgniter\Settings
+ * and Tatter\Preferences.
+ */
+class Preferences extends BaseConfig
+{
+}

--- a/src/Helpers/preferences_helper.php
+++ b/src/Helpers/preferences_helper.php
@@ -12,6 +12,11 @@ if (! function_exists('preference')) {
      */
     function preference(string $key, $value = null)
     {
+        // Check for shorthand requests
+        if (count(explode('.', $key)) === 1) {
+            $key = 'Preferences.' . $key;
+        }
+
         // Authenticated
         if ($userId = user_id()) {
             $settings = service('settings');

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -31,6 +31,13 @@ final class SettingsTest extends TestCase
         $this->assertSame('Orange', preference('Food.fruit'));
     }
 
+    public function testGetsShorthand()
+    {
+        config('Preferences')->food = 'Ghee';
+
+        $this->assertSame('Ghee', preference('food'));
+    }
+
     public function testForgets()
     {
         preference('Food.fruit', 'Celery');


### PR DESCRIPTION
* Provides a placeholder config file with corresponding docs
* Adds support for said config file via helper shorthands: `preference('foo')`