### PR TITLE
Suggest Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Persistent user-specific settings for CodeIgniter 4
 ## Description
 
 `Preferences` is a wrapper for [CodeIgniter Settings](https://github.com/codeigniter4/settings)
-to provide authenticated user context to each setting. This allows you to get and set preferences
-on a per-user basis with a single command.
+to provide user context to each setting. This allows you to get and set preferences on a
+per-user basis with a single command.
 
 ## Installation
 
@@ -31,10 +31,10 @@ Once the files are downloaded and included in the autoload, run any library migr
 to ensure the database is set up correctly:
 * `> php spark migrate -all`
 
-`Preferences` requires the Composer provision for `codeigniter4/authentication-implementation` as describe in the
-[CodeIgniter authentication guidelines](https://codeigniter4.github.io/CodeIgniter4/extending/authentication.html),
-so be sure to install a [supported package](https://packagist.org/providers/codeigniter4/authentication-implementation)
-as well.
+`Preferences` suggests the Composer provision for `codeigniter4/authentication-implementation` as describe in the
+[CodeIgniter authentication guidelines](https://codeigniter4.github.io/CodeIgniter4/extending/authentication.html).
+Without this each preference will be limited to the session duration so it is highly recommended
+you install and configure a [supported package](https://packagist.org/providers/codeigniter4/authentication-implementation).
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "codeigniter4/authentication-implementation": "^1.0",
         "codeigniter4/settings": "^2.1"
     },
     "require-dev": {
@@ -47,6 +46,9 @@
             "url": "https://github.com/codeigniter4/codeigniter4"
         }
     ],
+    "suggest": {
+        "codeigniter4/authentication-implementation": "Required to enable database persistence."
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {

--- a/src/Helpers/preferences_helper.php
+++ b/src/Helpers/preferences_helper.php
@@ -18,7 +18,7 @@ if (! function_exists('preference')) {
         }
 
         // Authenticated
-        if ($userId = user_id()) {
+        if (function_exists('user_id') && $userId = user_id()) {
             $settings = service('settings');
 
             // Getting


### PR DESCRIPTION
Loosens the requirement of `codeigniter4/authentication-implementation` to a suggestion, using the Session fallback when the helper function is missing.